### PR TITLE
Contract queries admin exclusion

### DIFF
--- a/src/main/java/org/launchcode/buildMyAppTriangle_20/controllers/AccountController.java
+++ b/src/main/java/org/launchcode/buildMyAppTriangle_20/controllers/AccountController.java
@@ -2,7 +2,6 @@ package org.launchcode.buildMyAppTriangle_20.controllers;
 
 import jakarta.validation.Valid;
 import org.launchcode.buildMyAppTriangle_20.models.User;
-import org.launchcode.buildMyAppTriangle_20.models.data.ContractRepository;
 import org.launchcode.buildMyAppTriangle_20.models.data.RoleRepository;
 import org.launchcode.buildMyAppTriangle_20.models.data.UserRepository;
 import org.launchcode.buildMyAppTriangle_20.security.MyUserDetailsService;
@@ -16,8 +15,6 @@ import org.springframework.ui.Model;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 @Controller
@@ -35,7 +32,7 @@ public class AccountController {
     public String index(Model model, @AuthenticationPrincipal UserDetails userDetails) {
         User currentUser = userRepository.findUserByUsername(userDetails.getUsername());
         if (currentUser.getUserRoles().contains(roleRepository.findByName("ROLE_ADMIN"))) {
-            model.addAttribute("admins", userRepository.findExclusiveAdmin());
+            model.addAttribute("admins", userRepository.findUserByExclusiveRole(1));
             model.addAttribute("employees", userRepository.findUserByRoleName("ROLE_EMPLOYEE"));
             model.addAttribute("customers", userRepository.findUserByRoleName("ROLE_CUSTOMER"));
         }
@@ -74,7 +71,7 @@ public class AccountController {
 
     @GetMapping("delete")
     public String displayDeleteEmployeeForm(Model model) {
-        model.addAttribute("employees", userRepository.findUserByRoleName("ROLE_EMPLOYEE"));
+        model.addAttribute("employees", userRepository.findUserByExclusiveRole(2)); //Finding by exclusive roll prevents admins who are also employees from being deleted.
         model.addAttribute("customers", userRepository.findUserByRoleName("ROLE_CUSTOMER"));
         return "accounts/delete";
     }

--- a/src/main/java/org/launchcode/buildMyAppTriangle_20/controllers/AccountController.java
+++ b/src/main/java/org/launchcode/buildMyAppTriangle_20/controllers/AccountController.java
@@ -34,12 +34,16 @@ public class AccountController {
     @GetMapping()
     public String index(Model model, @AuthenticationPrincipal UserDetails userDetails) {
         User currentUser = userRepository.findUserByUsername(userDetails.getUsername());
-        model.addAttribute("admins", userRepository.customSearch());
-        model.addAttribute("employees", userRepository.findUsersByMatchingContracts(userRepository.findAllUserContractIds(currentUser.getId()), "ROLE_EMPLOYEE"));
-        model.addAttribute("customers", userRepository.findUsersByMatchingContracts(userRepository.findAllUserContractIds(currentUser.getId()), "ROLE_CUSTOMER"));
-
-//        model.addAttribute("employees", userRepository.findUserByRoleName("ROLE_EMPLOYEE"));
-//        model.addAttribute("customers", userRepository.findUserByRoleName("ROLE_CUSTOMER"));
+        if (currentUser.getUserRoles().contains(roleRepository.findByName("ROLE_ADMIN"))) {
+            model.addAttribute("admins", userRepository.findUserByRoleName("ROLE_ADMIN"));
+            model.addAttribute("employees", userRepository.findUserByRoleName("ROLE_EMPLOYEE"));
+            model.addAttribute("customers", userRepository.findUserByRoleName("ROLE_CUSTOMER"));
+        }
+        else {
+            model.addAttribute("admins", userRepository.findUsersByMatchingContracts(userRepository.findAllUserContractIds(currentUser.getId()), "ROLE_ADMIN"));
+            model.addAttribute("employees", userRepository.findUsersByMatchingContracts(userRepository.findAllUserContractIds(currentUser.getId()), "ROLE_EMPLOYEE"));
+            model.addAttribute("customers", userRepository.findUsersByMatchingContracts(userRepository.findAllUserContractIds(currentUser.getId()), "ROLE_CUSTOMER"));
+        }
         return "accounts/index.html";
     }
     @GetMapping("add")

--- a/src/main/java/org/launchcode/buildMyAppTriangle_20/controllers/AccountController.java
+++ b/src/main/java/org/launchcode/buildMyAppTriangle_20/controllers/AccountController.java
@@ -35,7 +35,7 @@ public class AccountController {
     public String index(Model model, @AuthenticationPrincipal UserDetails userDetails) {
         User currentUser = userRepository.findUserByUsername(userDetails.getUsername());
         if (currentUser.getUserRoles().contains(roleRepository.findByName("ROLE_ADMIN"))) {
-            model.addAttribute("admins", userRepository.findUserByRoleName("ROLE_ADMIN"));
+            model.addAttribute("admins", userRepository.findExclusiveAdmin());
             model.addAttribute("employees", userRepository.findUserByRoleName("ROLE_EMPLOYEE"));
             model.addAttribute("customers", userRepository.findUserByRoleName("ROLE_CUSTOMER"));
         }

--- a/src/main/java/org/launchcode/buildMyAppTriangle_20/controllers/ContractController.java
+++ b/src/main/java/org/launchcode/buildMyAppTriangle_20/controllers/ContractController.java
@@ -2,8 +2,10 @@ package org.launchcode.buildMyAppTriangle_20.controllers;
 
 import jakarta.validation.Valid;
 import org.launchcode.buildMyAppTriangle_20.models.Contract;
+import org.launchcode.buildMyAppTriangle_20.models.Role;
 import org.launchcode.buildMyAppTriangle_20.models.User;
 import org.launchcode.buildMyAppTriangle_20.models.data.ContractRepository;
+import org.launchcode.buildMyAppTriangle_20.models.data.RoleRepository;
 import org.launchcode.buildMyAppTriangle_20.models.data.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,11 +25,20 @@ public class ContractController {
     private ContractRepository contractRepository;
     @Autowired
     private UserRepository userRepository;
+    @Autowired
+    private RoleRepository roleRepository;
 
     @GetMapping()
     public String index(Model model, @AuthenticationPrincipal UserDetails userDetails) {
+        Role admin = roleRepository.findByName("ROLE_ADMIN");
         User currentUser = userRepository.findUserByUsername(userDetails.getUsername());
-        model.addAttribute("contracts", contractRepository.findMatchingContracts(userRepository.findAllUserContractIds(currentUser.getId())));
+        // Check if user is admin. If admin, display all contracts. Else, only display relevant contracts.
+        if (currentUser.getUserRoles().contains(roleRepository.findByName("ROLE_ADMIN"))) {
+            model.addAttribute("contracts", contractRepository.findAll());
+        }
+        else {
+            model.addAttribute("contracts", contractRepository.findMatchingContracts(userRepository.findAllUserContractIds(currentUser.getId())));
+        }
         return "contracts/index";
     }
 

--- a/src/main/java/org/launchcode/buildMyAppTriangle_20/models/data/UserRepository.java
+++ b/src/main/java/org/launchcode/buildMyAppTriangle_20/models/data/UserRepository.java
@@ -24,6 +24,25 @@ public interface UserRepository extends CrudRepository<User, Long>, QueryRewrite
     @Query("SELECT u FROM User u INNER JOIN u.userRoles r WHERE r.name = :roleName")
     Iterable<User> findUserByRoleName(@Param("roleName") String roleName);
 
+    @Query(value= "SELECT *\n" +
+            "FROM user u\n" +
+            "WHERE EXISTS (\n" +
+            "\tSELECT 1\n" +
+            "    FROM users_roles ur\n" +
+            "    WHERE ur.user_id = u.id AND ur.role_id = 1\n" +
+            ")\n" +
+            "AND NOT EXISTS (\n" +
+            "\tSELECT 1\n" +
+            "    FROM users_roles ur\n" +
+            "    WHERE ur.user_id = u.id AND ur.role_id <> 1\n" +
+            ")",
+    nativeQuery = true)
+    Collection<User> findExclusiveAdmin();
+
+//    TODO: FIX THIS!!!
+//    @Query("SELECT u FROM User u INNER JOIN u.userRoles r WHERE r.name = :wantedRoleName and not r.name <> :excludedRoleName")
+//    Collection<User> findUserByRoleNameAndExcludedRoleName(@Param("wantedRoleName") String wantedRoleName, @Param("excludedRoleName") String excludedRoleName);
+
     //Finds all users who have matching role name associated with contractId
     @Query("SELECT u FROM User u JOIN u.contracts c JOIN u.userRoles r WHERE c.id = :contractId and r.name = :roleName")
     Collection<User> findUserByRoleAndContract(@Param("contractId") Long contractId, @Param("roleName") String roleName);

--- a/src/main/java/org/launchcode/buildMyAppTriangle_20/models/data/UserRepository.java
+++ b/src/main/java/org/launchcode/buildMyAppTriangle_20/models/data/UserRepository.java
@@ -24,20 +24,21 @@ public interface UserRepository extends CrudRepository<User, Long>, QueryRewrite
     @Query("SELECT u FROM User u INNER JOIN u.userRoles r WHERE r.name = :roleName")
     Iterable<User> findUserByRoleName(@Param("roleName") String roleName);
 
+    //Finds users who are exclusively within ONE role. For parameter, 1 = admin, 2 = employee, 3 = customer.
     @Query(value= "SELECT *\n" +
             "FROM user u\n" +
             "WHERE EXISTS (\n" +
             "\tSELECT 1\n" +
             "    FROM users_roles ur\n" +
-            "    WHERE ur.user_id = u.id AND ur.role_id = 1\n" +
+            "    WHERE ur.user_id = u.id AND ur.role_id = :exclusiveRoleId\n" +
             ")\n" +
             "AND NOT EXISTS (\n" +
             "\tSELECT 1\n" +
             "    FROM users_roles ur\n" +
-            "    WHERE ur.user_id = u.id AND ur.role_id <> 1\n" +
+            "    WHERE ur.user_id = u.id AND ur.role_id <> :exclusiveRoleId\n" +
             ")",
     nativeQuery = true)
-    Collection<User> findExclusiveAdmin();
+    Collection<User> findUserByExclusiveRole(@Param("exclusiveRoleId") Integer exclusiveRoleId);
 
 //    TODO: FIX THIS!!!
 //    @Query("SELECT u FROM User u INNER JOIN u.userRoles r WHERE r.name = :wantedRoleName and not r.name <> :excludedRoleName")

--- a/src/main/java/org/launchcode/buildMyAppTriangle_20/security/SetupDataLoader.java
+++ b/src/main/java/org/launchcode/buildMyAppTriangle_20/security/SetupDataLoader.java
@@ -47,17 +47,26 @@ import java.util.Collection;
 //        createRoleIfNotFound("ROLE_EMPLOYEE", Arrays.asList(readPrivilege));
 //        createRoleIfNotFound("ROLE_CUSTOMER", Arrays.asList(readPrivilege));
 //
-//        //Create default Admin
+//        //Create default Admin who isn't an employee
 //        Role defaultAdminUser = roleRepository.findByName("ROLE_ADMIN");
 //        Role defaultEmployeeUser = roleRepository.findByName("ROLE_EMPLOYEE");
 //        Role defaultCustomerUser = roleRepository.findByName("ROLE_CUSTOMER");
 //        User adminUser = new User();
-//        adminUser.setUsername("Paintgood@gmail.com");
-//        adminUser.setFirstName("John");
-//        adminUser.setLastName("Paintgood");
+//        adminUser.setUsername("Brushup@gmail.com");
+//        adminUser.setFirstName("Brush");
+//        adminUser.setLastName("Up");
 //        adminUser.setPassword(passwordEncoder.encode("12345"));
-//        adminUser.setUserRoles(Arrays.asList(defaultAdminUser, defaultEmployeeUser));
+//        adminUser.setUserRoles(Arrays.asList(defaultAdminUser));
 //        userRepository.save(adminUser);
+//
+//        //Create default Admin who is an employee
+//        User adminEmployeeUser = new User();
+//        adminEmployeeUser.setUsername("Paintgood@gmail.com");
+//        adminEmployeeUser.setFirstName("John");
+//        adminEmployeeUser.setLastName("Paintgood");
+//        adminEmployeeUser.setPassword(passwordEncoder.encode("12345"));
+//        adminEmployeeUser.setUserRoles(Arrays.asList(defaultAdminUser, defaultEmployeeUser));
+//        userRepository.save(adminEmployeeUser);
 //
 //        //Create default Employee
 //        User employeeUser = new User();

--- a/src/main/java/org/launchcode/buildMyAppTriangle_20/security/SetupDataLoader.java
+++ b/src/main/java/org/launchcode/buildMyAppTriangle_20/security/SetupDataLoader.java
@@ -49,16 +49,17 @@ import java.util.Collection;
 //
 //        //Create default Admin
 //        Role defaultAdminUser = roleRepository.findByName("ROLE_ADMIN");
+//        Role defaultEmployeeUser = roleRepository.findByName("ROLE_EMPLOYEE");
+//        Role defaultCustomerUser = roleRepository.findByName("ROLE_CUSTOMER");
 //        User adminUser = new User();
 //        adminUser.setUsername("Paintgood@gmail.com");
 //        adminUser.setFirstName("John");
 //        adminUser.setLastName("Paintgood");
 //        adminUser.setPassword(passwordEncoder.encode("12345"));
-//        adminUser.setUserRoles(Arrays.asList(defaultAdminUser));
+//        adminUser.setUserRoles(Arrays.asList(defaultAdminUser, defaultEmployeeUser));
 //        userRepository.save(adminUser);
 //
 //        //Create default Employee
-//        Role defaultEmployeeUser = roleRepository.findByName("ROLE_EMPLOYEE");
 //        User employeeUser = new User();
 //        employeeUser.setUsername("Jane@gmail.com");
 //        employeeUser.setFirstName("Jane");
@@ -68,7 +69,6 @@ import java.util.Collection;
 //        userRepository.save(employeeUser);
 //
 //        // Create default Customer
-//        Role defaultCustomerUser = roleRepository.findByName("ROLE_CUSTOMER");
 //        User customerUser = new User();
 //        customerUser.setUsername("Cantpaint@gmail.com");
 //        customerUser.setFirstName("Bob");


### PR DESCRIPTION
Changed the logic within the Account and Contract Controllers to check for and exclude admins from having limited views of accounts and contracts.
Added handling for admins who counted as both an admin and an employee via new SQL queries such that they will not appear twice and will be included or excluded from relevant data sets.